### PR TITLE
Fix link to jed

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -109,4 +109,4 @@ This project makes use of the Open Source packages listed below (see [package.js
 * parse-domain: https://github.com/peerigon/parse-domain
 
 ### Use: WTFPL, Contribute: Dojo CLA
-* jed: https://SlexAxton@github.com/SlexAxton/Jed
+* jed: https://github.com/SlexAxton/Jed


### PR DESCRIPTION
username is unnecessary and causes github to not display it as a link. 